### PR TITLE
🧹 Fix URL parameter encoding in `japanese_examples.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
 .DS_Store
+__pycache__/
+*.pyc

--- a/japanese_examples.py
+++ b/japanese_examples.py
@@ -25,9 +25,14 @@ def find_japanese_sentence(word, translation_language='eng'):
     - If there is an error connecting to the Tatoeba API, returns an error message.
     """
     # Construct the URL for the Tatoeba API search.
-    url = f"https://tatoeba.org/en/api_v0/search?query=%3D{word}&from=jpn&to={translation_language}"
+    url = "https://tatoeba.org/en/api_v0/search"
+    params = {
+        "query": f"={word}",
+        "from": "jpn",
+        "to": translation_language
+    }
     # Send a GET request to the Tatoeba API.
-    response = requests.get(url)
+    response = requests.get(url, params=params)
 
     # Check if the response status code is 200 (OK).
     if response.status_code == 200:

--- a/tests/test_japanese_examples_encoding.py
+++ b/tests/test_japanese_examples_encoding.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock
+import sys
+import os
+
+# Add parent directory to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Mock modules before importing the module under test
+sys.modules['aqt'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+
+# Now import the module to test
+from japanese_examples import find_japanese_sentence
+
+class TestJapaneseExamples(unittest.TestCase):
+    def setUp(self):
+        # Reset mocks before each test
+        sys.modules['requests'].get.reset_mock()
+        pass
+
+    def test_find_japanese_sentence_encoding(self):
+        word = "foo&bar"
+        lang = "eng"
+
+        # Call the function
+        find_japanese_sentence(word, lang)
+
+        # Get the call arguments
+        # If the function was called, call_args should not be None
+        if sys.modules['requests'].get.called:
+            args, kwargs = sys.modules['requests'].get.call_args
+        else:
+            self.fail("requests.get was not called")
+
+        # Assertions
+        # The first argument should be the base URL
+        # Currently (before fix) it is the full URL with query parameters
+        # After fix it should be just the base URL
+        self.assertEqual(args[0], "https://tatoeba.org/en/api_v0/search",
+                         f"Expected base URL, got {args[0]}")
+
+        # The params argument should be present
+        self.assertIn('params', kwargs, "params argument missing in requests.get call")
+
+        expected_params = {
+            'query': f'={word}',
+            'from': 'jpn',
+            'to': lang
+        }
+        self.assertEqual(kwargs['params'], expected_params)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses a code health issue where URL parameters were manually constructed using f-strings, leading to potential encoding issues with special characters. By switching to `requests.get(params=...)`, the library handles the encoding automatically and safely.

A new test case `tests/test_japanese_examples_encoding.py` was added to verify the fix.
Also updated `.gitignore` to exclude python cache files.

---
*PR created automatically by Jules for task [2447227948250109670](https://jules.google.com/task/2447227948250109670) started by @kthys*