### PR TITLE
🔒 Fix unhandled network request exceptions and add timeout

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -151,7 +151,7 @@ def add_example_manually_dialog(editor):
             showInfo(_('example_not_found'))
             return None
         
-        elif examples_sentences is str:
+        elif isinstance(examples_sentences, str):
             showInfo(examples_sentences)
             return None
         
@@ -171,7 +171,7 @@ def add_example_manually_dialog(editor):
             showInfo(_('example_not_found'))
             return None
         
-        elif examples_sentences is str:
+        elif isinstance(examples_sentences, str):
             showInfo(examples_sentences)
             return None
         

--- a/japanese_examples.py
+++ b/japanese_examples.py
@@ -32,7 +32,10 @@ def find_japanese_sentence(word, translation_language='eng'):
         "to": translation_language
     }
     # Send a GET request to the Tatoeba API.
-    response = requests.get(url, params=params)
+    try:
+        response = requests.get(url, params=params, timeout=10)
+    except requests.exceptions.RequestException:
+        return "Error: Unable to connect to Tatoeba API."
 
     # Check if the response status code is 200 (OK).
     if response.status_code == 200:

--- a/tests/test_japanese_examples_exceptions.py
+++ b/tests/test_japanese_examples_exceptions.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add parent directory to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class TestJapaneseExamplesExceptions(unittest.TestCase):
+
+    def setUp(self):
+        # Create mocks
+        self.mock_aqt = MagicMock()
+        self.mock_requests = MagicMock()
+
+        # Setup exceptions
+        class RequestException(Exception): pass
+        class ConnectionError(RequestException): pass
+        class Timeout(RequestException): pass
+
+        self.mock_requests.exceptions.RequestException = RequestException
+        self.mock_requests.exceptions.ConnectionError = ConnectionError
+        self.mock_requests.exceptions.Timeout = Timeout
+        self.mock_requests.get = MagicMock()
+
+        # Patch sys.modules
+        self.modules_patcher = patch.dict(sys.modules, {
+            'aqt': self.mock_aqt,
+            'requests': self.mock_requests
+        })
+        self.modules_patcher.start()
+
+        # Import the module under test
+        # We need to ensure it's imported with our mocks
+        if 'japanese_examples' in sys.modules:
+            del sys.modules['japanese_examples']
+        import japanese_examples
+        self.japanese_examples = japanese_examples
+
+    def tearDown(self):
+        self.modules_patcher.stop()
+        if 'japanese_examples' in sys.modules:
+            del sys.modules['japanese_examples']
+
+    def test_find_japanese_sentence_request_exception(self):
+        # Configure the mock to raise a RequestException
+        # We need to use the exception class from our mock
+        RequestException = self.mock_requests.exceptions.RequestException
+        self.mock_requests.get.side_effect = RequestException("Network error")
+
+        # Call the function
+        result = self.japanese_examples.find_japanese_sentence("word", "eng")
+
+        # Verify result
+        self.assertTrue(isinstance(result, str))
+        self.assertTrue(result.startswith("Error:"), f"Expected error message, got: {result}")
+
+    def test_find_japanese_sentence_timeout(self):
+        # Configure mock for successful response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        self.mock_requests.get.side_effect = None
+        self.mock_requests.get.return_value = mock_response
+
+        self.japanese_examples.find_japanese_sentence("word", "eng")
+
+        # Check if timeout was passed
+        if not self.mock_requests.get.called:
+             self.fail("requests.get was not called")
+
+        args, kwargs = self.mock_requests.get.call_args
+        self.assertIn('timeout', kwargs, "Timeout parameter missing in requests.get call")
+        self.assertEqual(kwargs['timeout'], 10, "Timeout should be 10 seconds")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed a security vulnerability in `japanese_examples.py` where `requests.get` could raise unhandled exceptions or hang indefinitely.

**Changes:**
- Wrapped `requests.get` call in a `try...except` block to catch `requests.exceptions.RequestException`.
- Added `timeout=10` parameter to the `requests.get` call to prevent Denial of Service (DoS) via resource exhaustion.
- Added a new test file `tests/test_japanese_examples_exceptions.py` to verify the fix and prevent regressions.

**Risk:**
- Without this fix, the application could crash or hang if the Tatoeba API is unreachable or slow, potentially leading to data loss or user frustration.
- The timeout prevents the application from waiting indefinitely for a response.

**Verification:**
- Verified the fix with a new reproduction test case that mocks network errors and timeouts.
- Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [3517900879048740818](https://jules.google.com/task/3517900879048740818) started by @kthys*