### PR TITLE
Fix: Dialog freeze when adding manual examples

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -54,14 +54,17 @@ def get_current_language():
     language = mw.pm.meta.get('defaultLang', 'en')
     return language
 
-def create_custom_dialog(message, choices, start_row=0):
+def create_custom_dialog(message, choices, start_row=0, parent=None):
     """ This function creates a custom dialog with a selection list
         and OK/Cancel buttons. It is based on code from Anki
         open-source project.
     """
 
-    # get the active window of the application
-    parent_window = mw.app.activeWindow()
+    # get the active window of the application if no parent is provided
+    if parent is None:
+        parent_window = mw.app.activeWindow()
+    else:
+        parent_window = parent
 
     # initialize a new dialog
     dialog = QDialog(parent_window)
@@ -200,9 +203,11 @@ def add_example_manually_dialog(editor):
                 return
 
         # User choses which example to add
+        # We pass the parent window explicitly to avoid attaching to the progress dialog
         example_picker_index = create_custom_dialog(
         _('select_sentence_dialog'),
-        examples
+        examples,
+        parent=editor.parentWindow
         )
 
         if example_picker_index is None:


### PR DESCRIPTION
Fix: Dialog freeze when adding manual examples

This commit resolves an issue where the "Select Sentence" dialog would cause the application to freeze or become unresponsive. The issue was caused by the new dialog being implicitly parented to the closing "Searching..." progress window when using `mw.app.activeWindow()`.

The fix involves:
1. Updating `create_custom_dialog` to accept an optional `parent` argument.
2. Passing the stable `editor.parentWindow` as the parent when creating the dialog in `add_example_manually_dialog`, ensuring it is not attached to the transient progress window.

---
*PR created automatically by Jules for task [3208476560230240856](https://jules.google.com/task/3208476560230240856) started by @kthys*