### PR TITLE
Skip language dialog when field is empty

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -118,6 +118,12 @@ def add_example_manually_dialog(editor):
         showInfo(_('select_field_to_use'))
         return
 
+    japanese_word = editor.note.fields[editor.web.editor.currentField]
+
+    if not japanese_word or not japanese_word.strip():
+        showInfo(_("no_japanese_sentence_found").format(word=japanese_word))
+        return
+
     # User choses where to get the examples from
     source_index = create_custom_dialog(
     _("select_translation_language_dialog"), 
@@ -128,8 +134,6 @@ def add_example_manually_dialog(editor):
     if source_index is None:
         return None
     
-    japanese_word = editor.note.fields[editor.web.editor.currentField]
-
     # Determine target language code
     if source_index == 0:
         target_lang = 'eng'

--- a/GUI.py
+++ b/GUI.py
@@ -214,7 +214,7 @@ def add_example_manually_dialog(editor):
             op=lambda col: find_japanese_sentence(japanese_word, target_lang),
             success=on_success
         )
-        op.with_progress(_("Searching...")).run_in_background()
+        op.with_progress(_("searching")).run_in_background()
     else:
         # Fallback for older versions: blocking call
         examples_sentences = find_japanese_sentence(japanese_word, target_lang)

--- a/locale/en.json
+++ b/locale/en.json
@@ -9,5 +9,6 @@
     "{DST_FIELD_TRANSLATION}_field_not_found": "{DST_FIELD_TRANSLATION} field not found in the current note.",
     "add_example_manually_tip": "Add an example sentence manually",
     "error_tatoeba_connection": "Error: Unable to connect to Tatoeba API.",
-    "no_japanese_sentence_found": "No Japanese sentence found containing the word '{word}'."
+    "no_japanese_sentence_found": "No Japanese sentence found containing the word '{word}'.",
+    "searching": "Searching..."
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -9,5 +9,6 @@
     "{DST_FIELD_TRANSLATION}_field_not_found": "Champs {DST_FIELD_TRANSLATION} non trouvé dans la note en cours d'édition.",
     "add_example_manually_tip": "Ajouter un exemple manuellement",
     "error_tatoeba_connection": "Erreur : Impossible de se connecter à l'API Tatoeba.",
-    "no_japanese_sentence_found": "Aucune phrase japonaise trouvée contenant le mot '{word}'."
+    "no_japanese_sentence_found": "Aucune phrase japonaise trouvée contenant le mot '{word}'.",
+    "searching": "Recherche..."
 }


### PR DESCRIPTION
Modified `GUI.py` to check if the selected field content is empty or whitespace-only before triggering the language selection dialog. If empty, an error message is shown immediately, skipping the unnecessary modal interaction.

This addresses the user request to streamline the error reporting for empty fields.

Verified with a reproduction test case that confirms the dialog is skipped and the error message is shown. Existing tests passed.

---
*PR created automatically by Jules for task [7528339761792111671](https://jules.google.com/task/7528339761792111671) started by @kthys*