### PR TITLE
Fix flush() deprecation warning in GUI.py

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -202,7 +202,7 @@ def add_example_manually_dialog(editor):
 
             # Save the changes to the note if the note already exists
             if note.id != 0 :
-                note.flush()
+                mw.col.update_note(note)
 
             # Update the editor to show the changes
             editor.loadNote()

--- a/tests/test_gui_async.py
+++ b/tests/test_gui_async.py
@@ -141,7 +141,7 @@ class TestGUIAsync(unittest.TestCase):
         self.assertEqual(editor.note.fields[1], 'TR1')
 
         # Verify flush and loadNote
-        editor.note.flush.assert_called_once()
+        self.mock_mw.col.update_note.assert_called_with(editor.note)
         editor.loadNote.assert_called_once()
 
     def test_fallback_when_queryop_missing(self):


### PR DESCRIPTION
Replaces deprecated `note.flush()` with `mw.col.update_note(note)` in `GUI.py` to fix console warnings. Updated unit tests to reflect this change. Verified manually with temporary reproduction scripts.

---
*PR created automatically by Jules for task [3014411487938895434](https://jules.google.com/task/3014411487938895434) started by @kthys*