### PR TITLE
Tests: Initial GUI Test Suite and Fix Async Test

### DIFF
--- a/tests/test_gui_async.py
+++ b/tests/test_gui_async.py
@@ -16,13 +16,21 @@ class TestGUIAsync(unittest.TestCase):
         self.mock_utils = MagicMock()
         self.mock_gui_hooks = MagicMock()
 
+        # Mock PyQt5
+        self.mock_pyqt5 = MagicMock()
+        self.mock_pyqt5_qtcore = MagicMock()
+        self.mock_pyqt5.QtCore = self.mock_pyqt5_qtcore
+        self.mock_pyqt5_qtcore.QTimer = MagicMock()
+
         # Patch sys.modules to simulate aqt existence
         self.modules_patcher = patch.dict(sys.modules, {
             'aqt': self.mock_aqt,
             'aqt.mw': self.mock_mw,
             'aqt.operations': self.mock_operations,
             'aqt.utils': self.mock_utils,
-            'aqt.gui_hooks': self.mock_gui_hooks
+            'aqt.gui_hooks': self.mock_gui_hooks,
+            'PyQt5': self.mock_pyqt5,
+            'PyQt5.QtCore': self.mock_pyqt5_qtcore
         })
         self.modules_patcher.start()
 
@@ -61,29 +69,7 @@ class TestGUIAsync(unittest.TestCase):
     def test_add_example_manually_dialog_flow(self, mock_showInfo, mock_create_custom_dialog, mock_find_japanese_sentence):
         # Setup mocks
         editor = MagicMock()
-        editor.web.editor.currentField = 'Expression'
-        # Note fields are usually a list of values, but here it seems accessed by index or something.
-        # Wait, the code: editor.note.fields[jp_field_index] = jp_sentence
-        # And: japanese_word = editor.note.fields[editor.web.editor.currentField]
-        # This implies fields is dict-like or Anki's Note object supports access by name?
-        # Standard Anki Note.fields is a list of strings. Access by name uses note['Name'].
-        # But `editor.note.fields` is usually the list.
-        # Let's check the code: `japanese_word = editor.note.fields[editor.web.editor.currentField]`
-        # If `currentField` is an index (int), this works.
-        # If `currentField` is a name (str), `note.fields` (list) would raise TypeError.
-        # But `editor.web.editor.currentField` usually returns the field index in older Anki, or name?
-
-        # In `GUI.py`: `japanese_word = editor.note.fields[editor.web.editor.currentField]`
-        # If `currentField` is int, fine.
-
-        # But later: `note.fields[jp_field_index] = jp_sentence`
-        # `jp_field_index` is found via `field_names.index(DST_FIELD_JAP)`.
-
-        # So `fields` behaves like a list.
-        # If `editor.web.editor.currentField` is an int (index), then `editor.note.fields` is list.
-
-        # Let's assume currentField is an int index for the mocking purpose.
-        editor.web.editor.currentField = 0
+        editor.web.editor.currentField = 0 # Assuming index
 
         # Mock fields list
         editor.note.fields = ['test_word', '', '']
@@ -126,6 +112,14 @@ class TestGUIAsync(unittest.TestCase):
 
         # Simulate success callback with results
         success_callback(mock_results)
+
+        # Execute the scheduled function by QTimer
+        # Verify singleShot called
+        self.mock_pyqt5_qtcore.QTimer.singleShot.assert_called()
+        timer_args = self.mock_pyqt5_qtcore.QTimer.singleShot.call_args[0]
+        # singleShot(delay, func)
+        scheduled_func = timer_args[1]
+        scheduled_func()
 
         # Verify second dialog (Example selection)
         mock_create_custom_dialog.assert_called_with(
@@ -172,6 +166,12 @@ class TestGUIAsync(unittest.TestCase):
 
                 # Call
                 self.GUI.add_example_manually_dialog(editor)
+
+                # QTimer should have been called in on_success
+                self.mock_pyqt5_qtcore.QTimer.singleShot.assert_called()
+                timer_args = self.mock_pyqt5_qtcore.QTimer.singleShot.call_args[0]
+                scheduled_func = timer_args[1]
+                scheduled_func()
 
                 # Verify find_japanese_sentence called directly (synchronously)
                 mock_find.assert_called_with('test_word', 'eng')

--- a/tests/test_gui_utilities.py
+++ b/tests/test_gui_utilities.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add parent directory to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class TestGUIUtilities(unittest.TestCase):
+
+    def setUp(self):
+        # Create mocks for aqt modules
+        self.mock_aqt = MagicMock()
+        self.mock_mw = MagicMock()
+        self.mock_operations = MagicMock()
+        self.mock_utils = MagicMock()
+        self.mock_gui_hooks = MagicMock()
+
+        # Mock PyQt5
+        self.mock_pyqt5 = MagicMock()
+        self.mock_pyqt5_qtcore = MagicMock()
+        self.mock_pyqt5.QtCore = self.mock_pyqt5_qtcore
+
+        # Configure QTimer
+        self.mock_qtimer = MagicMock()
+        self.mock_pyqt5_qtcore.QTimer = self.mock_qtimer
+
+        # Patch sys.modules to simulate aqt and PyQt5 existence
+        self.modules_patcher = patch.dict(sys.modules, {
+            'aqt': self.mock_aqt,
+            'aqt.mw': self.mock_mw,
+            'aqt.operations': self.mock_operations,
+            'aqt.utils': self.mock_utils,
+            'aqt.gui_hooks': self.mock_gui_hooks,
+            'PyQt5': self.mock_pyqt5,
+            'PyQt5.QtCore': self.mock_pyqt5_qtcore
+        })
+        self.modules_patcher.start()
+
+        # Link mw to aqt.mw
+        self.mock_aqt.mw = self.mock_mw
+
+        # Mock Qt constants
+        self.mock_utils.Qt = MagicMock()
+        # Default to Qt5
+        self.mock_utils.Qt.__module__ = 'PyQt5.QtCore'
+
+        # Mock japanese_examples because GUI imports from it
+        self.mock_japanese_examples = MagicMock()
+        self.mock_japanese_examples.DST_FIELD_JAP = 'Expression'
+        self.mock_japanese_examples.DST_FIELD_TRANSLATION = 'Meaning'
+        sys.modules['japanese_examples'] = self.mock_japanese_examples
+
+        # Import the module under test
+        if 'GUI' in sys.modules:
+            del sys.modules['GUI']
+        import GUI
+        self.GUI = GUI
+
+    def tearDown(self):
+        self.modules_patcher.stop()
+        if 'GUI' in sys.modules:
+            del sys.modules['GUI']
+        if 'japanese_examples' in sys.modules:
+            del sys.modules['japanese_examples']
+
+    def test_get_qt_version_qt5(self):
+        """Test get_qt_version returns 5 when Qt module is PyQt5."""
+        self.mock_utils.Qt.__module__ = 'PyQt5.QtCore'
+        self.assertEqual(self.GUI.get_qt_version(), 5)
+
+    def test_get_qt_version_qt6(self):
+        """Test get_qt_version returns 6 when Qt module is PyQt6."""
+        self.mock_utils.Qt.__module__ = 'PyQt6.QtCore'
+        self.assertEqual(self.GUI.get_qt_version(), 6)
+
+    def test_get_plugin_dir_path(self):
+        """Test get_plugin_dir_path returns correct path based on mw.col.path."""
+        # Setup mock collection path
+        # Assume standard structure: .../User 1/collection.anki2
+        # And plugin directory: .../addons21/plugin_name
+
+        collection_path = "/home/user/Anki/User 1/collection.anki2"
+        self.mock_mw.col.path = collection_path
+
+        # Expected path derivation
+        # user_dir = /home/user/Anki/User 1
+        # anki_dir = /home/user/Anki
+        # plugin_dir = /home/user/Anki/addons21/GUI (since __name__ is GUI)
+
+        expected_path = os.path.join("/home/user/Anki", "addons21", "GUI")
+
+        result = self.GUI.get_plugin_dir_path()
+        self.assertEqual(result, expected_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds an initial test suite for the `GUI` module, covering utility functions `get_qt_version` and `get_plugin_dir_path`. It also fixes the existing `tests/test_gui_async.py` which was failing due to missing `PyQt5` mocks and incorrect handling of asynchronous callbacks via `QTimer.singleShot`. This improves the overall test reliability and coverage for the GUI module.

---
*PR created automatically by Jules for task [6999788017389795742](https://jules.google.com/task/6999788017389795742) started by @kthys*