### PR TITLE
perf: reuse HTTP Session for Tatoeba API requests

### DIFF
--- a/japanese_examples.py
+++ b/japanese_examples.py
@@ -1,5 +1,8 @@
 import requests
 from aqt import mw
+
+# Use a global session for connection pooling to improve performance
+_session = requests.Session()
 try:
     from .i18n import _
 except ImportError:
@@ -39,7 +42,7 @@ def find_japanese_sentence(word, translation_language='eng'):
     }
     # Send a GET request to the Tatoeba API.
     try:
-        response = requests.get(url, params=params, timeout=10)
+        response = _session.get(url, params=params, timeout=10)
     except requests.exceptions.RequestException:
         return _("error_tatoeba_connection")
 

--- a/tests/test_japanese_examples_encoding.py
+++ b/tests/test_japanese_examples_encoding.py
@@ -11,12 +11,15 @@ sys.modules['aqt'] = MagicMock()
 sys.modules['requests'] = MagicMock()
 
 # Now import the module to test
-from japanese_examples import find_japanese_sentence
+import japanese_examples
+import importlib
 
 class TestJapaneseExamples(unittest.TestCase):
     def setUp(self):
+        # Reload the module to ensure it uses the current mock for requests
+        importlib.reload(japanese_examples)
         # Reset mocks before each test
-        sys.modules['requests'].get.reset_mock()
+        japanese_examples._session.get.reset_mock()
         pass
 
     def test_find_japanese_sentence_encoding(self):
@@ -24,14 +27,14 @@ class TestJapaneseExamples(unittest.TestCase):
         lang = "eng"
 
         # Call the function
-        find_japanese_sentence(word, lang)
+        japanese_examples.find_japanese_sentence(word, lang)
 
         # Get the call arguments
         # If the function was called, call_args should not be None
-        if sys.modules['requests'].get.called:
-            args, kwargs = sys.modules['requests'].get.call_args
+        if japanese_examples._session.get.called:
+            args, kwargs = japanese_examples._session.get.call_args
         else:
-            self.fail("requests.get was not called")
+            self.fail("session.get was not called")
 
         # Assertions
         # The first argument should be the base URL

--- a/tests/test_japanese_examples_exceptions.py
+++ b/tests/test_japanese_examples_exceptions.py
@@ -21,6 +21,10 @@ class TestJapaneseExamplesExceptions(unittest.TestCase):
         self.mock_requests.exceptions.RequestException = RequestException
         self.mock_requests.exceptions.ConnectionError = ConnectionError
         self.mock_requests.exceptions.Timeout = Timeout
+
+        # Mock Session
+        self.mock_session = MagicMock()
+        self.mock_requests.Session.return_value = self.mock_session
         self.mock_requests.get = MagicMock()
 
         # Patch sys.modules
@@ -46,7 +50,7 @@ class TestJapaneseExamplesExceptions(unittest.TestCase):
         # Configure the mock to raise a RequestException
         # We need to use the exception class from our mock
         RequestException = self.mock_requests.exceptions.RequestException
-        self.mock_requests.get.side_effect = RequestException("Network error")
+        self.mock_session.get.side_effect = RequestException("Network error")
 
         # Call the function
         result = self.japanese_examples.find_japanese_sentence("word", "eng")
@@ -60,17 +64,17 @@ class TestJapaneseExamplesExceptions(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {}
-        self.mock_requests.get.side_effect = None
-        self.mock_requests.get.return_value = mock_response
+        self.mock_session.get.side_effect = None
+        self.mock_session.get.return_value = mock_response
 
         self.japanese_examples.find_japanese_sentence("word", "eng")
 
         # Check if timeout was passed
-        if not self.mock_requests.get.called:
-             self.fail("requests.get was not called")
+        if not self.mock_session.get.called:
+             self.fail("session.get was not called")
 
-        args, kwargs = self.mock_requests.get.call_args
-        self.assertIn('timeout', kwargs, "Timeout parameter missing in requests.get call")
+        args, kwargs = self.mock_session.get.call_args
+        self.assertIn('timeout', kwargs, "Timeout parameter missing in session.get call")
         self.assertEqual(kwargs['timeout'], 10, "Timeout should be 10 seconds")
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Initialize a global requests.Session object at module level.
- Use session.get instead of requests.get in find_japanese_sentence.
- Update tests to mock requests.Session and handle module-level state.
- Documentation of performance benefits included in the PR.