### PR TITLE
Add info tooltip to deck preference checkbox

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -1,6 +1,6 @@
 from aqt import gui_hooks, mw
 from aqt.utils import Qt, QDialog, QVBoxLayout, QLabel, QListWidget, QDialogButtonBox
-from aqt.qt import QCheckBox, QLineEdit, QPushButton, QFormLayout
+from aqt.qt import QCheckBox, QLineEdit, QPushButton, QFormLayout, QHBoxLayout
 from aqt.utils import showInfo
 import os, html
 
@@ -99,8 +99,16 @@ def create_custom_dialog(message, choices, start_row=0, parent=None, with_checkb
 
     checkbox = None
     if with_checkbox:
+        h_layout = QHBoxLayout()
         checkbox = QCheckBox(checkbox_text)
-        layout.addWidget(checkbox)
+        h_layout.addWidget(checkbox)
+
+        info_label = QLabel("ⓘ")
+        info_label.setToolTip(_("deck_preference_info_tooltip"))
+        h_layout.addWidget(info_label)
+
+        h_layout.addStretch()
+        layout.addLayout(h_layout)
 
     # set the standard buttons
     standard_buttons = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel

--- a/locale/en.json
+++ b/locale/en.json
@@ -16,5 +16,6 @@
     "settings_dialog_title": "Japanese Examples Addon Settings",
     "japanese_field_label": "Japanese Field Name:",
     "translation_field_label": "Translation Field Name:",
-    "deck_preferences_reset": "Deck preferences have been reset."
+    "deck_preferences_reset": "Deck preferences have been reset.",
+    "deck_preference_info_tooltip": "This language will be used as default for the current deck. This preference can be reset in the addon's settings."
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -16,5 +16,6 @@
     "settings_dialog_title": "Paramètres de l'addon",
     "japanese_field_label": "Nom du champ Japonais :",
     "translation_field_label": "Nom du champ Traduction :",
-    "deck_preferences_reset": "Les préférences de paquet ont été réinitialisées."
+    "deck_preferences_reset": "Les préférences de paquet ont été réinitialisées.",
+    "deck_preference_info_tooltip": "Cette langue sera utilisée comme défaut pour le paquet actuel. Cette préférence peut être réinitialisée dans les paramètres de l'addon."
 }

--- a/tests/test_gui_utilities.py
+++ b/tests/test_gui_utilities.py
@@ -15,6 +15,7 @@ class TestGUIUtilities(unittest.TestCase):
         self.mock_operations = MagicMock()
         self.mock_utils = MagicMock()
         self.mock_gui_hooks = MagicMock()
+        self.mock_qt = MagicMock()
 
         # Mock PyQt5
         self.mock_pyqt5 = MagicMock()
@@ -32,7 +33,7 @@ class TestGUIUtilities(unittest.TestCase):
             'aqt.operations': self.mock_operations,
             'aqt.utils': self.mock_utils,
             'aqt.gui_hooks': self.mock_gui_hooks,
-            'aqt.qt': MagicMock(),
+            'aqt.qt': self.mock_qt,
             'PyQt5': self.mock_pyqt5,
             'PyQt5.QtCore': self.mock_pyqt5_qtcore
         })
@@ -93,6 +94,53 @@ class TestGUIUtilities(unittest.TestCase):
 
         result = self.GUI.get_plugin_dir_path()
         self.assertEqual(result, expected_path)
+
+    def test_create_custom_dialog_with_checkbox_adds_tooltip(self):
+        """Test create_custom_dialog adds a tooltip and icon when checkbox is enabled."""
+        # Setup mocks
+        mock_dialog = self.mock_utils.QDialog.return_value
+        mock_dialog.exec.return_value = 1  # OK
+
+        mock_selection_list = self.mock_utils.QListWidget.return_value
+        mock_selection_list.currentRow.return_value = 0
+
+        mock_checkbox = self.mock_qt.QCheckBox.return_value
+        mock_checkbox.isChecked.return_value = True
+
+        # Call function
+        result = self.GUI.create_custom_dialog(
+            "Test Message",
+            ["Choice 1", "Choice 2"],
+            with_checkbox=True,
+            checkbox_text="Save default"
+        )
+
+        # Verify layout structure
+        # Should create QHBoxLayout
+        self.assertTrue(self.mock_qt.QHBoxLayout.called, "QHBoxLayout should be instantiated")
+        mock_h_layout = self.mock_qt.QHBoxLayout.return_value
+
+        # Should create QLabel for info icon
+        # Check if QLabel was called with "ⓘ"
+        # Since QLabel is called multiple times (for message and info icon), check call_args_list
+        calls = self.mock_utils.QLabel.call_args_list
+        info_icon_created = any(call[0][0] == "ⓘ" for call in calls)
+        self.assertTrue(info_icon_created, "Info icon QLabel('ⓘ') should be created")
+
+        # Find the mock for the info label to verify setToolTip
+        # It's tricky because return_value is the same mock object for all calls by default unless side_effect is used.
+        # But we can check if setToolTip was called on the return value of QLabel.
+        mock_label = self.mock_utils.QLabel.return_value
+        mock_label.setToolTip.assert_called()
+
+        # Verify widgets added to HBox
+        # mock_h_layout.addWidget called with checkbox and label
+        self.assertTrue(mock_h_layout.addWidget.called)
+
+        # Verify HBox added to main layout (VBox)
+        # Main layout is created via QVBoxLayout()
+        mock_v_layout = self.mock_utils.QVBoxLayout.return_value
+        mock_v_layout.addLayout.assert_called_with(mock_h_layout)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added an info icon with a tooltip next to the "Use as default for this deck" checkbox in the language selection dialog.
This tooltip explains that the setting saves the default language for the current deck and can be reset in the settings.
Updated English and French localization files with the tooltip text.
Updated `GUI.py` to use `QHBoxLayout` for the checkbox layout.
Updated `tests/test_gui_utilities.py` to verify the new layout and tooltip.