### PR TITLE
🧪 Add unit tests for config_ui.on_config

### DIFF
--- a/tests/test_config_ui.py
+++ b/tests/test_config_ui.py
@@ -121,6 +121,21 @@ class TestConfigUI(unittest.TestCase):
         self.assertIsNotNone(dialog.config)
         self.assertEqual(dialog.config["deck_preferences"], {})
 
+    # ── on_config ───────────────────────────────────────────────────
+
+    def test_on_config_instantiates_and_executes_dialog(self):
+        """Should instantiate ConfigDialog with the active window and call exec()."""
+        mock_active_window = MagicMock()
+        self.mock_mw.app.activeWindow.return_value = mock_active_window
+
+        with patch('config_ui.ConfigDialog') as MockDialog:
+            mock_dialog_instance = MockDialog.return_value
+
+            self.config_ui.on_config()
+
+            MockDialog.assert_called_once_with(mock_active_window)
+            mock_dialog_instance.exec.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have implemented a unit test for the `on_config` function in `config_ui.py`. 

🎯 **What:** The testing gap addressed was the untested `on_config` function, which is the entry point for the configuration dialog.
📊 **Coverage:** The new test verifies that `ConfigDialog` is instantiated with the correct parent window (`mw.app.activeWindow()`) and that `.exec()` is called on it.
✨ **Result:** Increased test coverage for the configuration UI logic and ensured that the entry point functions as expected.

I also verified that the test fails if `dialog.exec()` is not called, and confirmed that the full test suite still passes.

---
*PR created automatically by Jules for task [5131830201963420173](https://jules.google.com/task/5131830201963420173) started by @kthys*