### PR TITLE
🔒 Fix SQL Wildcard Injection in Tatoeba Data Search

### DIFF
--- a/src/core/tatoeba_data.py
+++ b/src/core/tatoeba_data.py
@@ -178,13 +178,14 @@ def search_word(db_path: str, word: str, conn: Optional[sqlite3.Connection] = No
     try:
         local_conn = conn if conn is not None else sqlite3.connect(db_path)
         cur = local_conn.cursor()
+        safe_word = word.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
         cur.execute(f"""
             SELECT DISTINCT s.jpn_text, s.trans_text
             FROM words w
             JOIN sentences s ON w.sentence_id = s.id
             WHERE {token_query}
-              AND s.jpn_text LIKE ?
-        """, (primary_token, f"%{word}%"))
+              AND s.jpn_text LIKE ? ESCAPE '\\'
+        """, (primary_token, f"%{safe_word}%"))
         results = cur.fetchall()
         if conn is None:
             local_conn.close()


### PR DESCRIPTION
🎯 **What:** Fixed a SQL wildcard injection vulnerability in `tatoeba_data.py`.
⚠️ **Risk:** User-provided search strings that included literal `%` or `_` characters would modify the SQLite `LIKE` operator's pattern matching logic, returning unintended results and allowing potential logic-based injection attacks against the local index.
🛡️ **Solution:** Escaped the wildcard characters (`%`, `_`) and the escape character (`\`) in the `word` string before inserting it into the `LIKE` clause. Additionally appended the explicit `ESCAPE '\'` syntax in the SQLite query.

---
*PR created automatically by Jules for task [17810103009941327645](https://jules.google.com/task/17810103009941327645) started by @kthys*